### PR TITLE
Fix subnet uuid references

### DIFF
--- a/contrail_api_cli_extra/clean/subnet.py
+++ b/contrail_api_cli_extra/clean/subnet.py
@@ -53,8 +53,7 @@ class CleanSubnet(CheckCommand):
                 vn_uuid = str("%s %s/%s" % (vn['uuid'],
                                             subnet['subnet']['ip_prefix'],
                                             subnet['subnet']['ip_prefix_len']))
-                subnet_uuid = str(
-                    vn['attr']['ipam_subnets'][0]['subnet_uuid'])
+                subnet_uuid = str(subnet['subnet_uuid'])
 
                 kv.update({subnet_uuid: vn_uuid})
                 kv.update({vn_uuid: subnet_uuid})


### PR DESCRIPTION
* Since ipam-subnets hold multiple items we have to get the subnet uuid
  over all the subnets in the list.